### PR TITLE
perf(diagonalize): More efficient isotope mass lookup

### DIFF
--- a/src/com_pac/diagonalize.py
+++ b/src/com_pac/diagonalize.py
@@ -5,8 +5,14 @@
 # ========= #
 from mendeleev.mendeleev import isotope
 
-from mendeleev import element
 import numpy as np
+
+
+ISOTOPE_MASS_CACHE = {}
+
+
+def clear_isotope_mass_cache():
+    ISOTOPE_MASS_CACHE.clear()
 
 
 def get_inertia_matrix(coordinates_array, masses_array):
@@ -88,12 +94,18 @@ def get_unique_isotopes(isotopes_dict):
 
 
 def get_isotopes_mass(symbol, mass_number):
+    cache_key = (symbol, mass_number)
+    if cache_key in ISOTOPE_MASS_CACHE:
+        return ISOTOPE_MASS_CACHE[cache_key]
+
     try:
         mass = isotope(symbol, mass_number).mass
     except Exception as exc:
         raise ValueError(
             f"Isotopic mass not found for {symbol} with mass number {mass_number}."
-        )
+        ) from exc
+
+    ISOTOPE_MASS_CACHE[cache_key] = mass
 
     return mass
 

--- a/tests/com_pac/test_diagonalize.py
+++ b/tests/com_pac/test_diagonalize.py
@@ -9,6 +9,7 @@ from mendeleev.mendeleev import element
 
 import pytest
 import numpy as np
+import com_pac.diagonalize as diagonalize
 from com_pac.diagonalize import (
     get_inertia_matrix,
     inertia_to_rot_const,
@@ -1188,6 +1189,58 @@ class Test_get_isotopes_mass:
         assert exc.type is ValueError and (
             "Isotopic mass not found for AF with mass number 123." in str(exc.value)
         )
+
+
+class Test_get_isotopes_mass_cache:
+    @pytest.fixture(autouse=True)
+    def clear_cache(self):
+        diagonalize.clear_isotope_mass_cache()
+        yield
+        diagonalize.clear_isotope_mass_cache()
+
+    def test_repeated_lookup_hits_cache(self, monkeypatch):
+        calls = []
+
+        class _MockIsotope:
+            def __init__(self, mass):
+                self.mass = mass
+
+        def mock_isotope(symbol, mass_number):
+            calls.append((symbol, mass_number))
+            return _MockIsotope(1.2345)
+
+        monkeypatch.setattr(diagonalize, "isotope", mock_isotope)
+
+        result1 = get_isotopes_mass("H", 1)
+        result2 = get_isotopes_mass("H", 1)
+
+        assert np.allclose(result1, 1.2345)
+        assert np.allclose(result2, 1.2345)
+        assert calls == [("H", 1)]
+
+    def test_distinct_keys_each_lookup_once(self, monkeypatch):
+        calls = []
+        mass_map = {
+            ("H", 1): 1.0,
+            ("H", 2): 2.0,
+        }
+
+        class _MockIsotope:
+            def __init__(self, mass):
+                self.mass = mass
+
+        def mock_isotope(symbol, mass_number):
+            calls.append((symbol, mass_number))
+            return _MockIsotope(mass_map[(symbol, mass_number)])
+
+        monkeypatch.setattr(diagonalize, "isotope", mock_isotope)
+
+        assert np.allclose(get_isotopes_mass("H", 1), 1.0)
+        assert np.allclose(get_isotopes_mass("H", 2), 2.0)
+        assert np.allclose(get_isotopes_mass("H", 1), 1.0)
+
+        assert calls.count(("H", 1)) == 1
+        assert calls.count(("H", 2)) == 1
 
 
 @pytest.fixture


### PR DESCRIPTION
Previously had a loop over each isotopologue, and inside of that loop it would look up the mass of each unique isotope. Since most isotopologues share many of the same isotopes, this caused a lot of redundant lookups.

Implmented a caching mechanism so that once the mass of a particular isotope is looked up, it is stored in a dictionary. Subsequent isotopologues that require the same isotope can then retrieve the mass from the cache instead of performing another lookup.